### PR TITLE
Fix: resolves issue #134 by unsqueezing 1D outputs.

### DIFF
--- a/pyrelational/strategies/classification/abstract_classification_strategy.py
+++ b/pyrelational/strategies/classification/abstract_classification_strategy.py
@@ -46,6 +46,9 @@ class ClassificationStrategy(Strategy, ABC):
         :return: list of indices to annotate
         """
         output = self.train_and_infer(data_manager=data_manager, model_manager=model_manager).mean(0)
+        if output.dim() == 1:
+            # Unsqueezes at dimension 0, making a 1D tensor 2D
+            output = output.unsqueeze(0)
         if not torch.allclose(output.sum(1), torch.tensor(1.0)):
             output = softmax(output)
         uncertainty = self.scoring_function(softmax(output))


### PR DESCRIPTION
## What is the goal of this PR?

Fix bug #134 to allow classification strategies to deal with 1D model output better.

## What are the changes implemented in this PR?

Before testing to see if the model output has been softmaxed in the abstract classification strategy class we have added a test to see if the output is 1D or not. If it is 1D then it now unsqueezes the output so that it is now 2D - as expected by the softmax test.